### PR TITLE
glusterfs.spec.in: remove condtionals from tar dependency (#2734)

### DIFF
--- a/glusterfs.spec.in
+++ b/glusterfs.spec.in
@@ -442,9 +442,8 @@ Requires:         python%{_pythonver}-gluster = %{version}-%{release}
 
 Requires:         rsync
 Requires:         util-linux
-%if ( 0%{?rhel} && ( ( 0%{?rhel} == 8 && 0%{?rhel_minor_version} >= 3 ) || 0%{?rhel} >= 9 ) )
 Requires:         tar
-%endif
+
 # required for setting selinux bools
 %if ( 0%{?rhel} && 0%{?rhel} >= 8 )
 Requires(post):      policycoreutils-python-utils


### PR DESCRIPTION
* glusterfs.spec.in: remove condtionals from tar dependency

The conditional on rhel minor version fails and tar is not
marked as required.

As there is not any universal macro to specify the
minor release, removing the conditionals above the
"Requires: tar" statement

with this change irrespective of rhel 8.3 and
above, tar will be marked required for geo-rep.

Change-Id: Id1e3320a0b1a245fc9cd8c7acb09cc119fca18b8
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>

* Update glusterfs.spec.in

